### PR TITLE
feat(frontend): add Sider(#18)

### DIFF
--- a/frontend/src/components/SidebarMenu/SideBarMenu.tsx
+++ b/frontend/src/components/SidebarMenu/SideBarMenu.tsx
@@ -1,0 +1,32 @@
+import { StyledSidebarMenu, StyledSidebarItem } from './SidebarMenu.styled';
+import * as AntdIcons from '@ant-design/icons';
+
+interface itemProp {
+  label: string;
+  href: string;
+  icon: string;
+}
+
+interface itemsProp {
+  items: itemProp[];
+}
+
+export const SidebarMenu = ({ items }: itemsProp) => {
+  return (
+    <StyledSidebarMenu>
+      {items.map((item) => {
+        const CustomIcon = (type: string) => {
+          // eslint-disable-next-line no-console
+          const AntdIcon = AntdIcons[type];
+          return <AntdIcon />;
+        };
+        return (
+          <StyledSidebarItem>
+            {CustomIcon(item?.icon)}
+            {item?.label}
+          </StyledSidebarItem>
+        );
+      })}
+    </StyledSidebarMenu>
+  );
+};

--- a/frontend/src/components/SidebarMenu/SidebarMenu.styled.ts
+++ b/frontend/src/components/SidebarMenu/SidebarMenu.styled.ts
@@ -1,0 +1,12 @@
+import styled, { css } from 'styled-components';
+import { Menu as AntMenu } from 'antd';
+
+export const StyledSidebarMenu = styled(AntMenu)`
+  padding-top: 58px;
+`;
+
+export const StyledSidebarItem = styled(AntMenu.Item)`
+  &:not(:last-child) {
+    border-bottom: 1px solid grey;
+  }
+`;

--- a/frontend/src/views/App/App.tsx
+++ b/frontend/src/views/App/App.tsx
@@ -2,6 +2,7 @@ import { AppHeader } from 'components/AppHeader/AppHeader';
 import { AppRoutes } from 'routes/AppRoutes';
 import { usePageTitle } from 'providers/PageTitleProvider';
 import { Layout } from 'antd';
+import { SidebarMenu } from 'components/SidebarMenu/SideBarMenu';
 
 import { AppContent, AppFooter } from './App.styled';
 
@@ -13,7 +14,16 @@ export const App = () => {
     <Layout>
       <AppHeader pageTitle={title} />
       <Layout>
-        <Sider />
+        <Sider>
+          <SidebarMenu
+            items={[
+              { label: 'Priority tasks', href: '/', icon: 'FileExclamationOutlined' },
+              { label: 'Ungrouped', href: '/statistics', icon: 'FileExclamationOutlined' },
+              { label: 'Projects', href: '/projects', icon: 'FileExclamationOutlined' },
+              { label: 'Statistic', href: '/statistics', icon: 'FileExclamationOutlined' },
+            ]}
+          />
+        </Sider>
         <AppContent>
           <AppRoutes />
         </AppContent>


### PR DESCRIPTION
 Stworzyłam Sider, chciałam dodać ikony do niego i utknęłam.
Problem leży w ``const AntdIcon = AntdIcons[type];``` błąd to ```Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'typeof import("/Users/newuser/Desktop/coderscamp/projects/CodersCamp2021.Project-4.TaskManager/frontend/node_modules/@ant-design/icons/lib/index")'.
  No index signature with a parameter of type 'string' was found on type 'typeof import("/Users/newuser/Desktop/coderscamp/projects/CodersCamp2021.Project-4.TaskManager/frontend/node_modules/@ant-design/icons/lib/index")'.``` Chciałam sprawdzić, czy ta metoda w ogóle zadziała z ant design, ale nie mogę też wyłączyć eslinta, żeby to sprawdzić. I tak się męczę od wczoraj. Nie ogarniam tego indexowania :P

![1](https://user-images.githubusercontent.com/46648993/167361323-4adb5d8a-cf55-4366-bc4d-4161baa303aa.png)
![2](https://user-images.githubusercontent.com/46648993/167361328-98877485-0329-4edc-b227-cfd449692521.png)
