### PR TITLE
feat: Modal

### DIFF
--- a/frontend/src/components/Modal/Modal.styles.ts
+++ b/frontend/src/components/Modal/Modal.styles.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import { Modal } from 'antd';
+
+export const StyledModal = styled(Modal)`
+  .ant-btn-primary {
+    border-color: ${({ theme }) => theme.colors.primary};
+    background: ${({ theme }) => theme.colors.primary};
+    &:hover {
+      background: ${({ theme }) => theme.colors.hoverPrimary};
+      border-color: ${({ theme }) => theme.colors.hoverPrimary};
+    }
+    &:focus,
+    &:active {
+      background: ${({ theme }) => theme.colors.activePrimary};
+      border-color: ${({ theme }) => theme.colors.activePrimary};
+    }
+  }
+  .ant-btn-default {
+    border-color: ${({ theme }) => theme.colors.primary};
+    color: ${({ theme }) => theme.colors.primary};
+    &:hover {
+      color: ${({ theme }) => theme.colors.hoverPrimary};
+      border-color: ${({ theme }) => theme.colors.hoverPrimary};
+    }
+    &:focus,
+    &:active {
+      border-color: ${({ theme }) => theme.colors.activePrimary};
+      color: ${({ theme }) => theme.colors.activePrimary};
+    }
+  }
+`;

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -20,17 +20,15 @@ export const Modal = ({
   children,
 }: ModalProps) => {
   return (
-    <>
-      <StyledModal
-        title={title}
-        visible={isVisible}
-        okText={submitButtonLabel ?? 'submit'}
-        cancelText={cancelButtonLabel ?? 'cancel'}
-        onOk={(e) => onSubmit(e)}
-        onCancel={() => onCancel()}
-      >
-        {children}
-      </StyledModal>
-    </>
+    <StyledModal
+      title={title}
+      visible={isVisible}
+      okText={submitButtonLabel ?? 'submit'}
+      cancelText={cancelButtonLabel ?? 'cancel'}
+      onOk={(e) => onSubmit(e)}
+      onCancel={() => onCancel()}
+    >
+      {children}
+    </StyledModal>
   );
 };

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -1,0 +1,36 @@
+import { StyledModal } from './Modal.styles';
+
+export interface ModalProps {
+  title?: string;
+  isVisible: boolean;
+  onCancel: () => void;
+  onSubmit: (e: React.SyntheticEvent) => void;
+  submitButtonLabel?: string;
+  cancelButtonLabel?: string;
+  children: React.ReactNode;
+}
+
+export const Modal = ({
+  title,
+  isVisible,
+  onCancel,
+  onSubmit,
+  submitButtonLabel,
+  cancelButtonLabel,
+  children,
+}: ModalProps) => {
+  return (
+    <>
+      <StyledModal
+        title={title}
+        visible={isVisible}
+        okText={submitButtonLabel ?? 'submit'}
+        cancelText={cancelButtonLabel ?? 'cancel'}
+        onOk={(e) => onSubmit(e)}
+        onCancel={() => onCancel()}
+      >
+        {children}
+      </StyledModal>
+    </>
+  );
+};

--- a/frontend/src/components/Modal/ModalExample.tsx
+++ b/frontend/src/components/Modal/ModalExample.tsx
@@ -1,0 +1,23 @@
+import { Modal } from './Modal';
+import { Button } from '../Button/Button';
+import { useModal } from './useModal';
+
+export const ModalExample = () => {
+  const { isModalVisible, toggleModalVisibility } = useModal();
+
+  return (
+    <>
+      <Button htmlType="button" type="primary" color="primary" handleClick={toggleModalVisibility}>
+        Open Example Modal
+      </Button>
+      <Modal
+        title="Modal Example"
+        isVisible={isModalVisible}
+        onSubmit={toggleModalVisibility}
+        onCancel={toggleModalVisibility}
+      >
+        <p>Some contents...</p>
+      </Modal>
+    </>
+  );
+};

--- a/frontend/src/components/Modal/useModal.ts
+++ b/frontend/src/components/Modal/useModal.ts
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+
+export const useModal = () => {
+    const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+
+    const toggleModalVisibility = () => {
+        setIsModalVisible(!isModalVisible);
+    };
+    return { isModalVisible, toggleModalVisibility }
+}


### PR DESCRIPTION
Dodaj uniwersalny modal.

Jeśli AntDesign nie ma innego rozwiązania, to skorzystaj z React Portal.
Komponent ma mieć 2 przyciski - "anuluj" oraz "zatwierdź".
Komponent ma wyświetlać swoje dziecko i wyświetlać je powyżej przycisków.
Nazwy przycisków można zmienić przez propsy.
Przekaż callbacki do przycisków przez propsy.
Kliknięcie przycisków ma dodatkowo zamykać modala

![image](https://user-images.githubusercontent.com/28146348/167710751-197c2789-60a1-41c8-9488-d2ad62e820ba.png)
